### PR TITLE
Fix missing ability to add item tags

### DIFF
--- a/lib/services/littlelight/item_notes.service.dart
+++ b/lib/services/littlelight/item_notes.service.dart
@@ -42,16 +42,14 @@ class ItemNotesService with StorageConsumer {
     return _defaultTags.values.toList() + (_tags?.values.toList() ?? []);
   }
 
-  Future<Map<String, ItemNotes>> getNotes({forceFetch = false}) async {
-    final _notes = this._notes;
-    if (_notes != null && !forceFetch) {
-      return _notes;
-    }
+   Future<Map<String, ItemNotes>> getNotes({forceFetch = false}) async {
+    if (_notes != null && !forceFetch) return _notes!;
+
     await _loadNotesFromCache();
-    if (forceFetch || _notes == null) {
-      await _fetchNotes();
-    }
-    return _notes ?? Map();
+    if (forceFetch || _notes == null) await _fetchNotes();
+
+    _notes = _notes ?? Map<String, ItemNotes>();
+    return _notes!;
   }
 
   Future<bool> _loadNotesFromCache() async {


### PR DESCRIPTION
This should fix #131 by making sure the `_notes` object *isn't* null. Maybe it's worth to make sure this object non-nullable?