### PR TITLE
Added Quest Step Counter

### DIFF
--- a/lib/widgets/item_details/main_info/item_main_info.widget.dart
+++ b/lib/widgets/item_details/main_info/item_main_info.widget.dart
@@ -37,7 +37,7 @@ class ItemMainInfoWidgetState extends BaseDestinyItemState<ItemMainInfoWidget> w
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text(definition?.itemTypeDisplayName ?? ""),
+              Text(getEnhancedDefinitionName(definition)),
               Padding(padding: EdgeInsets.only(top: 8), child: primaryStat(context))
             ],
           ),
@@ -58,6 +58,19 @@ class ItemMainInfoWidgetState extends BaseDestinyItemState<ItemMainInfoWidget> w
           buildWishListInfo(context),
           // buildLockInfo(context),
         ]));
+  }
+
+  String getEnhancedDefinitionName(DestinyInventoryItemDefinition definition) {
+    String itemTypeDisplayName = definition?.itemTypeDisplayName ?? "";
+
+    if ((definition?.itemCategoryHashes?.indexOf(16) ?? -1) >= 0) {
+      List<int> stepHashes = definition.setData.itemList.map((i) => i.itemHash)?.toList() ?? [];
+      int currentIndex = stepHashes.indexOf(item.itemHash);
+      int allSteps = stepHashes.length;
+      return itemTypeDisplayName + " (${currentIndex + 1}/$allSteps)";
+    }
+
+    return itemTypeDisplayName;
   }
 
   Widget buildEmblemInfo(BuildContext context) {

--- a/lib/widgets/item_details/main_info/item_main_info.widget.dart
+++ b/lib/widgets/item_details/main_info/item_main_info.widget.dart
@@ -63,7 +63,8 @@ class ItemMainInfoWidgetState extends BaseDestinyItemState<ItemMainInfoWidget> w
   String getEnhancedDefinitionName(DestinyInventoryItemDefinition definition) {
     String itemTypeDisplayName = definition?.itemTypeDisplayName ?? "";
 
-    if ((definition?.itemCategoryHashes?.indexOf(16) ?? -1) >= 0) {
+    final questCategoryHash = 16;
+    if (definition?.itemCategoryHashes?.contains(questCategoryHash) ?? false) {
       List<int> stepHashes = definition.setData.itemList.map((i) => i.itemHash)?.toList() ?? [];
       int currentIndex = stepHashes.indexOf(item.itemHash);
       int allSteps = stepHashes.length;

--- a/lib/widgets/item_details/quest_info.widget.dart
+++ b/lib/widgets/item_details/quest_info.widget.dart
@@ -35,7 +35,6 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
   bool showSpoilers = false;
 
   int currentIndex = 0;
-  int allSteps = 0;
 
   @override
   void initState() {
@@ -49,7 +48,6 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
         await manifest.getDefinition<DestinyInventoryItemDefinition>(definition.objectives.questlineItemHash);
     List<int> stepHashes = questlineDefinition.setData?.itemList?.map((i) => i.itemHash)?.toList() ?? [];
     currentIndex = stepHashes.indexOf(item.itemHash);
-    allSteps = stepHashes.length;
     questSteps = await manifest.getDefinitions<DestinyInventoryItemDefinition>(stepHashes);
     Iterable<int> objectiveHashes = questSteps.values.expand((step) => step.objectives.objectiveHashes);
     objectiveDefinitions = await manifest.getDefinitions<DestinyObjectiveDefinition>(objectiveHashes);
@@ -69,12 +67,7 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
           padding: EdgeInsets.all(8),
           child: HeaderWidget(
             alignment: Alignment.centerLeft,
-            child: Row(
-              children: [
-                TranslatedTextWidget("Quest steps", uppercase: true, style: TextStyle(fontWeight: FontWeight.bold)),
-                Text(" ${currentIndex + 1}/$allSteps", style: TextStyle(fontWeight: FontWeight.bold)),
-              ],
-            ),
+            child: TranslatedTextWidget("Quest steps", uppercase: true, style: TextStyle(fontWeight: FontWeight.bold)),
           ),
         ),
       );

--- a/lib/widgets/item_details/quest_info.widget.dart
+++ b/lib/widgets/item_details/quest_info.widget.dart
@@ -35,6 +35,7 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
   bool showSpoilers = false;
 
   int currentIndex = 0;
+  int allSteps = 0;
 
   @override
   void initState() {
@@ -48,6 +49,7 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
         await manifest.getDefinition<DestinyInventoryItemDefinition>(definition.objectives.questlineItemHash);
     List<int> stepHashes = questlineDefinition.setData?.itemList?.map((i) => i.itemHash)?.toList() ?? [];
     currentIndex = stepHashes.indexOf(item.itemHash);
+    allSteps = stepHashes.length;
     questSteps = await manifest.getDefinitions<DestinyInventoryItemDefinition>(stepHashes);
     Iterable<int> objectiveHashes = questSteps.values.expand((step) => step.objectives.objectiveHashes);
     objectiveDefinitions = await manifest.getDefinitions<DestinyObjectiveDefinition>(objectiveHashes);
@@ -62,12 +64,20 @@ class QuestInfoWidgetState extends BaseDestinyItemState<QuestInfoWidget> with Pr
     }
     items.add(buildQuestline(context));
     if ((questSteps?.length ?? 0) > 0) {
-      items.add(Container(
+      items.add(
+        Container(
           padding: EdgeInsets.all(8),
           child: HeaderWidget(
-              alignment: Alignment.centerLeft,
-              child: TranslatedTextWidget("Quest steps",
-                  uppercase: true, style: TextStyle(fontWeight: FontWeight.bold)))));
+            alignment: Alignment.centerLeft,
+            child: Row(
+              children: [
+                TranslatedTextWidget("Quest steps", uppercase: true, style: TextStyle(fontWeight: FontWeight.bold)),
+                Text(" ${currentIndex + 1}/$allSteps", style: TextStyle(fontWeight: FontWeight.bold)),
+              ],
+            ),
+          ),
+        ),
+      );
     }
     items.addAll(buildQuestSteps(context));
     if (currentIndex < questlineDefinition.setData.itemList.length && !showSpoilers) {


### PR DESCRIPTION
This Quality of Life changes adds a fraction/counter to the top of the Quest Info view.

The idea behind the implementation is to allow any other `itemTypeDisplayName`s to add "enhanced" information.

The [lib/widgets/item_details/quest_info.widget.dart](https://github.com/LittleLightForDestiny/littlelight/compare/main...TheBrenny:quest_steps?expand=1#diff-9f574d00134c00ec4ed047bf2a96bc480831f4ac4ea780f531b2bbcf42891d8d) file has no functional changes, and only contains formatting changes. This is because of a revert that I did where instead of showing the counter a second time further down the page, it only shows it once at the top.