### PR TITLE
Updated grind optimizer to show progress bar and per item diffs, fixed achievableAverage

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
 
   uni_links: ^0.5.1
   uni_links_macos: ^0.4.0
+  step_progress_indicator: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.1.7


### PR DESCRIPTION
Added progress bar to show fractional amount over level.
Added difference values to each max power item.
Fixed issue in achievableAverage function. Changed it to use int math, continue looping only with whole level increases, and start looping with all slots brought up to powerfulCap.