### PR TITLE
Added partial level progress bar, power level diff on each item, fixed _achievableAverage

### DIFF
--- a/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
+++ b/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
@@ -133,18 +133,17 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
     return totalPower / itemCount;
   }
 
-  // Find the highest achievable power level without the use of pinnacle rewards. This is
-  // to help players decide whether to go for powerful or pinnacle rewards when leveling up.
+  // Find the highest achievable power level without getting above power rewards. This is
+  // to help players decide whether to go for on power or above power rewards when leveling up.
   // As of season 20:
   //   - When below the powerful cap, powerful rewards will drop above power level.
-  //   - When at or above the powerful cap, powerfuls drop at power level.
+  //   - When at or above the powerful cap, powerfuls drop at power level and only pinnacle
+  //     rewards will drop above level.
   double _getAchievableAverage(Map<int, DestinyItemInfo> maxPowerEquipment) {
     final equipmentPower = maxPowerEquipment //
         .values
         .map((e) => (e.instanceInfo?.primaryStat?.value ?? 0));
-    int powerfulCap = _gameData?.powerfulCap ?? 1800;
-    // Bring each slot up to the powerfulCap since powerfuls can get us there
-    int totalPower = equipmentPower.fold(0, (t, c) => t + max(c, powerfulCap));
+    int totalPower = equipmentPower.fold(0, (t, c) => t + c);
     final itemCount = maxPowerEquipment.length;
     int currentBase;
     int iterations = 300; // This shouldn't be necessary
@@ -243,9 +242,9 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
   Map<int, DestinyItemInfo>? getEquippableMaxPowerItems(DestinyClass classType) => _maxEquippable?[classType];
 
   bool achievedPowerfulTier(DestinyClass classType) =>
-      (_achievableAverage?[classType] ?? 0) > (_gameData?.softCap ?? double.maxFinite);
+      (_achievableAverage?[classType] ?? 0) >= (_gameData?.softCap ?? double.maxFinite);
   bool achievedPinnacleTier(DestinyClass classType) =>
-      (_achievableAverage?[classType] ?? 0) > (_gameData?.powerfulCap ?? double.maxFinite);
+      (_achievableAverage?[classType] ?? 0) >= (_gameData?.powerfulCap ?? double.maxFinite);
   bool goForReward(DestinyClass classType) {
     if (!achievedPowerfulTier(classType)) return false;
     final current = (getCurrentAverage(classType) ?? 0).floor();

--- a/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
+++ b/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
@@ -42,10 +42,12 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
     final achievableAverage = state.getAchievableAverage(classType) ?? 0;
     final achievableDiff = achievableAverage.floor() - currentAverage.floor();
     final isInPinnacle = state.achievedPinnacleTier(classType);
-    // TODO: check if it works for powerfuls
     final goForReward = state.goForReward(classType);
-    final message =
+    final gofor_message =
         isInPinnacle ? "Go for pinnacle reward?".translate(context) : "Go for powerful reward?".translate(context);
+    final achievable_message = isInPinnacle
+        ? "Achievable without pinnacles:".translate(context)
+        : "Achievable without powerfuls:".translate(context);
     final items = state.getMaxPowerItems(classType);
     final itemCount = items?.length ?? 8;
     return MenuBox(
@@ -75,13 +77,13 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
       ),
       MenuInfoBox(
         child: Row(children: [
-          Expanded(child: Text("Achievable without pinnacles".translate(context) + ":")),
+          Expanded(child: Text(achievable_message)),
           Text("+$achievableDiff  ", style: TextStyle(color: achievableDiff > 0 ? Colors.greenAccent : Colors.white)),
           Text("${achievableAverage.toStringAsFixed(2)}"),
         ]),
       ),
       MenuBoxTitle(
-        message,
+        gofor_message,
         trailing: Text(goForReward ? "Yes".translate(context).toUpperCase() : "No".translate(context).toUpperCase()),
       ),
       if (items != null)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
 
   uni_links: ^0.5.1
   uni_links_macos: ^0.4.0
+  step_progress_indicator: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.1.7


### PR DESCRIPTION
Added progress bar to show fractional amount over level.
Added difference values to each max power item.
Fixed issue in achievableAverage function. Changed it to use int math to avoid any rounding issues, continue looping only with whole level increases.
Changed achievedPowerfulTier and achievedPinnacleTier to use >= instead of >