### PR TITLE
Added partial level progress bar, show power level diffs on items, fixed achievableAverage

### DIFF
--- a/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
+++ b/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
@@ -128,7 +128,7 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
     final totalPower = maxPowerEquipment //
         .values
         .map<int>((e) => e.instanceInfo?.primaryStat?.value ?? 0)
-        .fold<int>(0, (t, c) => t + c);
+        .fold<int>(0, (total, current) => total + current);
     final itemCount = maxPowerEquipment.length;
     return totalPower / itemCount;
   }
@@ -143,14 +143,13 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
     final equipmentPower = maxPowerEquipment //
         .values
         .map((e) => (e.instanceInfo?.primaryStat?.value ?? 0));
-    int totalPower = equipmentPower.fold(0, (t, c) => t + c);
+    int totalPower = equipmentPower.fold(0, (total, current) => total + current);
     final itemCount = maxPowerEquipment.length;
     int currentBase;
-    int iterations = 300; // This shouldn't be necessary
     do {
       currentBase = totalPower ~/ itemCount;
-      totalPower = equipmentPower.fold(0, (t, c) => t + max(c, currentBase));
-    } while (totalPower ~/ itemCount > currentBase && iterations-- > 0);
+      totalPower = equipmentPower.fold(0, (total, current) => total + max(current, currentBase));
+    } while (totalPower ~/ itemCount > currentBase);
     return totalPower / itemCount;
   }
 

--- a/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
+++ b/lib/shared/blocs/context_menu_options/context_menu_options.bloc.dart
@@ -11,6 +11,7 @@ import 'package:little_light/services/bungie_api/enums/inventory_bucket_hash.enu
 import 'package:little_light/services/littlelight/littlelight_data.consumer.dart';
 import 'package:little_light/services/manifest/manifest.consumer.dart';
 import 'package:provider/provider.dart';
+import 'dart:math';
 
 const _equipmentBuckets = {
   InventoryBucket.kineticWeapons,
@@ -100,7 +101,7 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
 
     final maxEquippable = maxPower.map((k, v) => MapEntry(k, _getMaxEquippableLoadout(v, maxPowerNonExotic[k]!)));
     final currentAverage = maxPower.map((k, v) => MapEntry(k, _getEquipmentAverage(v)));
-    final achievableAverage = maxPower.map((k, v) => MapEntry(k, _getAchievableAverage(currentAverage[k]!, v)));
+    final achievableAverage = maxPower.map((k, v) => MapEntry(k, _getAchievableAverage(v)));
     final equippableAverage = maxEquippable.map((k, v) => MapEntry(k, _getEquipmentAverage(v)));
     _maxPowerEquipments = maxPower;
     _maxEquippable = maxEquippable;
@@ -132,20 +133,25 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
     return totalPower / itemCount;
   }
 
-  double _getAchievableAverage(double currentAverage, Map<int, DestinyItemInfo> maxPowerEquipment) {
-    double? achievable;
-    int iterations = 0;
+  // Find the highest achievable power level without getting above power rewards. This is
+  // to help players decide whether to go for on power or above power rewards when leveling up.
+  // As of season 20:
+  //   - When below the powerful cap, powerful rewards will drop above power level.
+  //   - When at or above the powerful cap, powerfuls drop at power level and only pinnacle
+  //     rewards will drop above level.
+  double _getAchievableAverage(Map<int, DestinyItemInfo> maxPowerEquipment) {
     final equipmentPower = maxPowerEquipment //
         .values
-        .map<double>((e) => (e.instanceInfo?.primaryStat?.value ?? 0).toDouble());
-    while (achievable == null || achievable > currentAverage || iterations > 300) {
-      if (achievable != null) currentAverage = achievable;
-      final totalPower = equipmentPower.fold<double>(0, (t, c) => t + c.clamp(currentAverage, double.maxFinite));
-      final itemCount = maxPowerEquipment.length;
-      achievable = totalPower / itemCount;
-      iterations++;
-    }
-    return achievable;
+        .map((e) => (e.instanceInfo?.primaryStat?.value ?? 0));
+    int totalPower = equipmentPower.fold(0, (t, c) => t + c);
+    final itemCount = maxPowerEquipment.length;
+    int currentBase;
+    int iterations = 300; // This shouldn't be necessary
+    do {
+      currentBase = totalPower ~/ itemCount;
+      totalPower = equipmentPower.fold(0, (t, c) => t + max(c, currentBase));
+    } while (totalPower ~/ itemCount > currentBase && iterations-- > 0);
+    return totalPower / itemCount;
   }
 
   Map<int, DestinyItemInfo> _getMaxEquippableLoadout(
@@ -236,9 +242,9 @@ class ContextMenuOptionsBloc extends ChangeNotifier with ManifestConsumer, Littl
   Map<int, DestinyItemInfo>? getEquippableMaxPowerItems(DestinyClass classType) => _maxEquippable?[classType];
 
   bool achievedPowerfulTier(DestinyClass classType) =>
-      (_achievableAverage?[classType] ?? 0) > (_gameData?.softCap ?? double.maxFinite);
+      (_achievableAverage?[classType] ?? 0) >= (_gameData?.softCap ?? double.maxFinite);
   bool achievedPinnacleTier(DestinyClass classType) =>
-      (_achievableAverage?[classType] ?? 0) > (_gameData?.powerfulCap ?? double.maxFinite);
+      (_achievableAverage?[classType] ?? 0) >= (_gameData?.powerfulCap ?? double.maxFinite);
   bool goForReward(DestinyClass classType) {
     if (!achievedPowerfulTier(classType)) return false;
     final current = (getCurrentAverage(classType) ?? 0).floor();

--- a/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
+++ b/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
@@ -11,6 +11,7 @@ import 'package:little_light/shared/widgets/containers/menu_info_box.dart';
 import 'package:little_light/shared/widgets/containers/menu_box_title.dart';
 import 'package:provider/provider.dart';
 import 'package:tinycolor2/tinycolor2.dart';
+import 'package:step_progress_indicator/step_progress_indicator.dart';
 
 const List<int> _bucketsOrder = [
   InventoryBucket.kineticWeapons,
@@ -37,37 +38,54 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
     if (classType == null) return Container();
     final state = context.watch<ContextMenuOptionsBloc>();
     final currentAverage = state.getCurrentAverage(classType);
-    final achievableAverage = state.getAchievableAverage(classType);
+    if (currentAverage == null) return Container();
+    final achievableAverage = state.getAchievableAverage(classType) ?? 0;
+    final achievableDiff = achievableAverage.floor() - currentAverage.floor();
     final isInPinnacle = state.achievedPinnacleTier(classType);
     final goForReward = state.goForReward(classType);
-    final message =
+    final gofor_message =
         isInPinnacle ? "Go for pinnacle reward?".translate(context) : "Go for powerful reward?".translate(context);
+    final achievable_message = isInPinnacle
+        ? "Achievable without pinnacles:".translate(context)
+        : "Achievable without powerfuls:".translate(context);
     final items = state.getMaxPowerItems(classType);
+    final itemCount = items?.length ?? 8;
     return MenuBox(
         child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+      MenuInfoBox(
+        child: Column(
+          children: [
+            Row(children: [
+              Expanded(child: Text("Current base power".translate(context) + ":")),
+              Text("${currentAverage.toStringAsFixed(2)}"),
+            ]),
+            Container(height: 5),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text("${currentAverage.toInt()} ", textScaleFactor: .8),
+                Expanded(
+                  child: StepProgressIndicator(
+                      totalSteps: itemCount,
+                      currentStep: ((currentAverage - currentAverage.floor()) * itemCount).round()),
+                ),
+                Text(" ${currentAverage.toInt() + 1}", textScaleFactor: .8),
+              ],
+            ),
+          ],
+        ),
+      ),
+      MenuInfoBox(
+        child: Row(children: [
+          Expanded(child: Text(achievable_message)),
+          Text("+$achievableDiff  ", style: TextStyle(color: achievableDiff > 0 ? Colors.greenAccent : Colors.white)),
+          Text("${achievableAverage.toStringAsFixed(2)}"),
+        ]),
+      ),
       MenuBoxTitle(
-        message,
+        gofor_message,
         trailing: Text(goForReward ? "Yes".translate(context).toUpperCase() : "No".translate(context).toUpperCase()),
       ),
-      IntrinsicHeight(
-          child: Row(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Expanded(
-              child: MenuInfoBox(
-                  child: Column(children: [
-            Text("Current average".translate(context)),
-            Text("${currentAverage?.toStringAsFixed(2)}"),
-          ]))),
-          SizedBox(width: 4),
-          Expanded(
-              child: MenuInfoBox(
-                  child: Column(children: [
-            Text("Achievable average".translate(context)),
-            Text("${achievableAverage?.toStringAsFixed(2)}"),
-          ]))),
-        ],
-      )),
       if (items != null)
         SingleChildScrollView(
           scrollDirection: Axis.horizontal,
@@ -76,53 +94,39 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
                 .map((hash) {
                   final item = items[hash];
                   if (item == null) return null;
-                  final average = currentAverage?.floor() ?? 0;
-                  final diff = item.instanceInfo?.primaryStat?.value?.compareTo(average) ?? 0;
-                  String text = "Average".translate(context);
-                  IconData icon = FontAwesomeIcons.equals;
-                  Color bg = context.theme.onSurfaceLayers.layer3;
-                  Color color = context.theme.onSurfaceLayers.layer1;
+                  final average = currentAverage.toInt();
+                  final diff = (item.instanceInfo?.primaryStat?.value ?? average) - average;
+                  String text = "+" + diff.toString();
+                  Color color = Colors.white;
                   if (diff > 0) {
-                    text = "Above".translate(context);
-                    icon = FontAwesomeIcons.solidSquareCaretUp;
-                    bg = context.theme.successLayers.layer0;
-                    color = context.theme.successLayers.layer3;
+                    color = Colors.greenAccent;
                   }
                   if (diff < 0) {
-                    text = "Below".translate(context);
-                    icon = FontAwesomeIcons.solidSquareCaretDown;
-                    bg = context.theme.errorLayers.layer0;
-                    color = context.theme.errorLayers.layer3;
+                    text = diff.toString();
+                    color = Colors.red;
                   }
                   return Container(
-                      width: 64,
-                      margin: EdgeInsets.only(right: 2),
-                      child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+                    width: 64,
+                    margin: EdgeInsets.only(right: 2),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
                         Container(
                           height: 64,
                           margin: EdgeInsets.only(bottom: 2),
                           child: LowDensityInventoryItem(item),
                         ),
                         Container(
-                          color: bg.withOpacity(.3),
+                          color: Colors.black,
                           padding: EdgeInsets.symmetric(horizontal: 2),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                text,
-                                style: context.textTheme.caption
-                                    .copyWith(color: color.mix(context.theme.onSurfaceLayers, 70)),
-                              ),
-                              Icon(
-                                icon,
-                                size: 12,
-                                color: color.mix(context.theme.onSurfaceLayers, 70),
-                              )
-                            ],
-                          ),
+                          child: Text(text,
+                              textScaleFactor: 1.1,
+                              style: TextStyle(color: color, fontWeight: FontWeight.bold),
+                              textAlign: TextAlign.center),
                         )
-                      ]));
+                      ],
+                    ),
+                  );
                 })
                 .whereType<Widget>()
                 .toList(),

--- a/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
+++ b/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
@@ -11,7 +11,6 @@ import 'package:little_light/shared/widgets/containers/menu_info_box.dart';
 import 'package:little_light/shared/widgets/containers/menu_box_title.dart';
 import 'package:provider/provider.dart';
 import 'package:tinycolor2/tinycolor2.dart';
-import 'package:step_progress_indicator/step_progress_indicator.dart';
 
 const List<int> _bucketsOrder = [
   InventoryBucket.kineticWeapons,
@@ -32,6 +31,31 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
     required this.character,
   }) : super(key: key);
 
+  // Build step progress bar widget to show exactly how many slot points (power levels on
+  // individual items) are needed to reach the next higher power level.
+  Widget _buildPartialLevelProgressBar(BuildContext context, int itemCount, double currentAverage) {
+    final currentStep = ((currentAverage - currentAverage.floor()) * itemCount);
+    var bars = <Widget>[];
+    Color color = context.theme.primaryLayers.layer1;
+    for (int i = 0; i < itemCount; i++) {
+      if (i == currentStep) {
+        color = context.theme.onSurfaceLayers.layer3;
+      }
+      if (i > 0) {
+        bars.add(SizedBox(width: 4));
+      }
+      bars.add(Expanded(child: Container(height: 4, width: 4, color: color)));
+    }
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text("${currentAverage.toInt()}", textScaleFactor: .8),
+        Expanded(child: Container(padding: EdgeInsets.symmetric(horizontal: 6), child: Row(children: bars))),
+        Text("${currentAverage.toInt() + 1}", textScaleFactor: .8),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final classType = character.character.classType;
@@ -43,9 +67,9 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
     final achievableDiff = achievableAverage.floor() - currentAverage.floor();
     final isInPinnacle = state.achievedPinnacleTier(classType);
     final goForReward = state.goForReward(classType);
-    final gofor_message =
+    final goForMessage =
         isInPinnacle ? "Go for pinnacle reward?".translate(context) : "Go for powerful reward?".translate(context);
-    final achievable_message = isInPinnacle
+    final achievableMessage = isInPinnacle
         ? "Achievable without pinnacles:".translate(context)
         : "Achievable without powerfuls:".translate(context);
     final items = state.getMaxPowerItems(classType);
@@ -59,31 +83,23 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
               Expanded(child: Text("Current base power".translate(context) + ":")),
               Text("${currentAverage.toStringAsFixed(2)}"),
             ]),
-            Container(height: 5),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text("${currentAverage.toInt()} ", textScaleFactor: .8),
-                Expanded(
-                  child: StepProgressIndicator(
-                      totalSteps: itemCount,
-                      currentStep: ((currentAverage - currentAverage.floor()) * itemCount).round()),
-                ),
-                Text(" ${currentAverage.toInt() + 1}", textScaleFactor: .8),
-              ],
-            ),
+            SizedBox(height: 5),
+            _buildPartialLevelProgressBar(context, itemCount, currentAverage)
           ],
         ),
       ),
       MenuInfoBox(
         child: Row(children: [
-          Expanded(child: Text(achievable_message)),
-          Text("+$achievableDiff  ", style: TextStyle(color: achievableDiff > 0 ? Colors.greenAccent : Colors.white)),
+          Expanded(child: Text(achievableMessage)),
+          Text("+$achievableDiff  ",
+              style: TextStyle(
+                  color:
+                      achievableDiff > 0 ? context.theme.successLayers.layer3 : context.theme.onSurfaceLayers.layer0)),
           Text("${achievableAverage.toStringAsFixed(2)}"),
         ]),
       ),
       MenuBoxTitle(
-        gofor_message,
+        goForMessage,
         trailing: Text(goForReward ? "Yes".translate(context).toUpperCase() : "No".translate(context).toUpperCase()),
       ),
       if (items != null)
@@ -97,13 +113,13 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
                   final average = currentAverage.toInt();
                   final diff = (item.instanceInfo?.primaryStat?.value ?? average) - average;
                   String text = "+" + diff.toString();
-                  Color color = Colors.white;
+                  Color color = context.theme.onSurfaceLayers.layer0;
                   if (diff > 0) {
-                    color = Colors.greenAccent;
+                    color = context.theme.successLayers.layer3;
                   }
                   if (diff < 0) {
                     text = diff.toString();
-                    color = Colors.red;
+                    color = Color.fromARGB(255, 251, 121, 78);
                   }
                   return Container(
                     width: 64,
@@ -117,12 +133,10 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
                           child: LowDensityInventoryItem(item),
                         ),
                         Container(
-                          color: Colors.black,
+                          color: context.theme.surfaceLayers.layer0,
                           padding: EdgeInsets.symmetric(horizontal: 2),
                           child: Text(text,
-                              textScaleFactor: 1.1,
-                              style: TextStyle(color: color, fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center),
+                              style: TextStyle(color: color, fontWeight: FontWeight.bold), textAlign: TextAlign.center),
                         )
                       ],
                     ),

--- a/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
+++ b/lib/shared/widgets/menus/character_context_menu/grind_optimizer.widget.dart
@@ -41,16 +41,17 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
       if (i == currentStep) {
         color = context.theme.onSurfaceLayers.layer3;
       }
-      if (i > 0) {
-        bars.add(SizedBox(width: 4));
-      }
-      bars.add(Expanded(child: Container(height: 4, width: 4, color: color)));
+      bars.add(
+        Expanded(
+          child: Container(height: 4, width: 4, color: color, margin: EdgeInsets.symmetric(horizontal: 2)),
+        ),
+      );
     }
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text("${currentAverage.toInt()}", textScaleFactor: .8),
-        Expanded(child: Container(padding: EdgeInsets.symmetric(horizontal: 6), child: Row(children: bars))),
+        Expanded(child: Container(padding: EdgeInsets.symmetric(horizontal: 4), child: Row(children: bars))),
         Text("${currentAverage.toInt() + 1}", textScaleFactor: .8),
       ],
     );
@@ -73,18 +74,17 @@ class CharacterGrindOptimizerWidget extends StatelessWidget {
         ? "Achievable without pinnacles:".translate(context)
         : "Achievable without powerfuls:".translate(context);
     final items = state.getMaxPowerItems(classType);
-    final itemCount = items?.length ?? 8;
     return MenuBox(
         child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
       MenuInfoBox(
         child: Column(
           children: [
             Row(children: [
-              Expanded(child: Text("Current base power".translate(context) + ":")),
+              Expanded(child: Text("Current base power:".translate(context))),
               Text("${currentAverage.toStringAsFixed(2)}"),
             ]),
             SizedBox(height: 5),
-            _buildPartialLevelProgressBar(context, itemCount, currentAverage)
+            _buildPartialLevelProgressBar(context, items?.length ?? 8, currentAverage)
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,6 @@ dependencies:
 
   uni_links: ^0.5.1
   uni_links_macos: ^0.4.0
-  step_progress_indicator: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.1.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
 
   uni_links: ^0.5.1
   uni_links_macos: ^0.4.0
+  step_progress_indicator: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.1.7


### PR DESCRIPTION
Added progress bar to show fractional amount over level.
Added difference values to each max power item.
Fixed issue in achievableAverage function. Changed it to use int math to avoid any rounding issues, continue looping only with whole level increases.
Changed achievedPowerfulTier and achievedPinnacleTier to use >= instead of >