### PR TITLE
Base collections bloc was missing updating of actual inventory counts for collectible items

### DIFF
--- a/lib/modules/collections/blocs/base_collections.bloc.dart
+++ b/lib/modules/collections/blocs/base_collections.bloc.dart
@@ -99,14 +99,17 @@ abstract class CollectionsBloc extends ChangeNotifier {
     final itemHashes = collectibleDefinitions.values.map((c) => c.itemHash);
     final itemDefinitions = await manifest.getDefinitions<DestinyInventoryItemDefinition>(itemHashes);
     final genericItems = _genericItems ?? Map<int, DefinitionItemInfo>();
+    final inventoryItems = _inventoryItems ?? Map<int, List<InventoryItemInfo>>();
     for (final h in collectibleHashes) {
       final itemHash = collectibleDefinitions[h]?.itemHash;
       final def = itemDefinitions[itemHash];
       if (def == null) continue;
       final item = DefinitionItemInfo.fromDefinition(def);
       genericItems[h] = item;
+      inventoryItems[h] = profileBloc.getItemsByHash(itemHash);
     }
     _genericItems = genericItems;
+    _inventoryItems = inventoryItems;
   }
 
   @protected


### PR DESCRIPTION
In collections, the counts of actual inventory items was not showing on collectibles because the list was not being updated in collections bloc.