### PR TITLE
Fixed SmallArmorStatsWidget overflow, rearranged currencies with commas

### DIFF
--- a/lib/shared/widgets/character/character_info.widget.dart
+++ b/lib/shared/widgets/character/character_info.widget.dart
@@ -10,6 +10,7 @@ import 'package:little_light/widgets/common/definition_provider.widget.dart';
 import 'package:little_light/widgets/common/manifest_image.widget.dart';
 import 'package:little_light/widgets/common/manifest_text.widget.dart';
 import 'package:little_light/widgets/icon_fonts/littlelight_icons.dart';
+import 'package:intl/intl.dart';
 
 const _wellRestedProgression = 2352765282;
 
@@ -61,9 +62,10 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
   Widget buildCurrencies(BuildContext context) {
     final currencies = this.currencies;
     if (currencies == null) return Container();
+    final numberFormatter = NumberFormat.decimalPattern(context.currentLanguage);
     return Wrap(
       alignment: WrapAlignment.end,
-      children: currencies.reversed
+      children: currencies
           .map((e) => Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -75,9 +77,9 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
                   Container(
                     width: 4,
                   ),
-                  Text("${e.quantity}"),
+                  Text(numberFormatter.format(e.quantity)),
                   Container(width: 8),
-                ].reversed.toList(),
+                ].toList(),
               ))
           .toList(),
     );
@@ -115,7 +117,6 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
     if (stats == null) return SizedBox();
     return SmallArmorStatsWidget(
       stats,
-      textWidth: 24,
     );
   }
 
@@ -145,7 +146,7 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
     int overlevel = overLevelProg?.level ?? 0;
     int progress = level + overlevel;
     return Text(
-      "Seasonal Rank {rank}".translate(context, replace: {"rank": "$progress"}),
+      "Season Rank {rank}".translate(context, replace: {"rank": "$progress"}),
       style: context.textTheme.caption,
     );
   }
@@ -207,8 +208,11 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
     final currentProg = (levelProg?.level ?? 0) < (levelProg?.levelCap ?? 0) ? levelProg : overLevelProg;
     int progress = currentProg?.progressToNextLevel ?? 0;
     int total = currentProg?.nextLevelAt ?? 1;
+    final numberFormatter = NumberFormat.decimalPattern(context.currentLanguage);
+    String formattedProgress = numberFormatter.format(progress);
+    String formattedTotal = numberFormatter.format(total);
     return Text(
-      "$progress/$total",
+      "$formattedProgress/$formattedTotal",
       style: context.textTheme.caption,
     );
   }

--- a/lib/shared/widgets/inventory_item/inventory_item_stats.dart
+++ b/lib/shared/widgets/inventory_item/inventory_item_stats.dart
@@ -6,13 +6,9 @@ import 'package:little_light/shared/widgets/stats/small_armor_stats.widget.dart'
 class InventoryItemStats extends StatelessWidget with WishlistsConsumer {
   final DestinyItemInfo itemInfo;
   final double iconSize;
-  final double textWidth;
-  final EdgeInsets iconMargin;
   InventoryItemStats(
     this.itemInfo, {
     this.iconSize = 16,
-    this.textWidth = 18,
-    this.iconMargin = const EdgeInsets.only(right: 1),
   });
   @override
   Widget build(BuildContext context) {
@@ -20,8 +16,6 @@ class InventoryItemStats extends StatelessWidget with WishlistsConsumer {
     return SmallArmorStatsWidget(
       stats,
       iconSize: this.iconSize,
-      iconMargin: this.iconMargin,
-      textWidth: textWidth,
     );
   }
 }

--- a/lib/shared/widgets/stats/small_armor_stats.widget.dart
+++ b/lib/shared/widgets/stats/small_armor_stats.widget.dart
@@ -7,13 +7,13 @@ import 'package:little_light/widgets/common/manifest_image.widget.dart';
 class SmallArmorStatsWidget extends StatelessWidget with WishlistsConsumer {
   final Map<String, DestinyStat>? stats;
   final double iconSize;
-  final EdgeInsets iconMargin;
-  final double textWidth;
+  final double iconLeftMargin;
+  final double iconRightMargin;
   SmallArmorStatsWidget(
     this.stats, {
     this.iconSize = 16,
-    this.textWidth = 18,
-    this.iconMargin = const EdgeInsets.only(right: 1),
+    this.iconLeftMargin = 4,
+    this.iconRightMargin = 1,
   });
   @override
   Widget build(BuildContext context) {
@@ -21,48 +21,51 @@ class SmallArmorStatsWidget extends StatelessWidget with WishlistsConsumer {
     if (stats == null) return Container();
     final firstRow = stats.values.take(3);
     final secondRow = stats.values.skip(3).take(3);
-    return Column(children: [
-      Row(
-          children: firstRow //
-              .map((stat) => buildStat(context, stat))
-              .whereType<Widget>()
-              .toList()),
-      Row(
-          children: secondRow //
-              .map((stat) => buildStat(context, stat))
-              .whereType<Widget>()
-              .toList())
-    ]);
+    return Table(
+        defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+        defaultColumnWidth: IntrinsicColumnWidth(),
+        columnWidths: {
+          0: FixedColumnWidth(iconSize + iconRightMargin),
+          2: FixedColumnWidth(iconSize + iconLeftMargin + iconRightMargin),
+          4: FixedColumnWidth(iconSize + iconLeftMargin + iconRightMargin),
+        },
+        children: [
+          TableRow(
+              children: firstRow //
+                  .expand((stat) => buildStat(context, stat))
+                  .whereType<Widget>()
+                  .toList()),
+          TableRow(
+              children: secondRow //
+                  .expand((stat) => buildStat(context, stat))
+                  .whereType<Widget>()
+                  .toList())
+        ]);
   }
 
-  Widget? buildStat(BuildContext context, DestinyStat stat) {
+  List<Widget> buildStat(BuildContext context, DestinyStat stat) {
     final statHash = stat.statHash;
-    if (statHash == null) return null;
-    return Container(
-      child: Row(
-        children: [
-          Container(
-            margin: iconMargin,
-            width: iconSize,
-            height: iconSize,
-            child: ManifestImageWidget<DestinyStatDefinition>(statHash),
-          ),
-          SizedBox(
-            width: textWidth,
-            child: Text(
-              statValue(stat),
-              style: context.textTheme.subtitle.copyWith(fontSize: 12),
-              textAlign: TextAlign.end,
-            ),
-          ),
-          Container(width: 4),
-        ],
+    if (statHash == null) return [];
+    return [
+      Container(
+        margin: EdgeInsets.only(right: iconRightMargin),
+        width: iconSize,
+        height: iconSize,
+        alignment: Alignment.centerRight,
+        child: ManifestImageWidget<DestinyStatDefinition>(statHash),
       ),
-    );
+      Container(
+        child: Text(
+          statValue(stat),
+          style: context.textTheme.subtitle.copyWith(fontSize: 12),
+          textAlign: TextAlign.end,
+        ),
+      ),
+    ];
   }
 
   String statValue(DestinyStat stat) {
-    final value = stat.value?.clamp(0, 100) ?? 0;
+    final value = stat.value?.clamp(0, 999) ?? 0;
     return "$value".padLeft(2, "0");
   }
 }


### PR DESCRIPTION
- Changed SmallArmorStatsWidget to table to fix overflow
- Rearranged currencies and added locale-based number separators on character info page
- Added locale-based number separators to season rank progress
- Changed "Seasonal Rank" to "Season Rank" to match in-game display and save space