### PR TITLE
Add proper view padding to CharacterContextMenu, BottomSheet

### DIFF
--- a/lib/shared/widgets/character/character_info.widget.dart
+++ b/lib/shared/widgets/character/character_info.widget.dart
@@ -265,11 +265,13 @@ class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
         context: context,
         useRootNavigator: true,
         builder: (context) {
-          return Wrap(children: [
-            CharacterGrindOptimizerWidget(character: character, onClose: () => Navigator.pop(context)),
-            // Buttons don't work at the bottom
-            SizedBox(height: 24, width: 32)
-          ]);
+          return SafeArea(
+            child: Wrap(
+              children: [
+                CharacterGrindOptimizerWidget(character: character, onClose: () => Navigator.pop(context)),
+              ],
+            ),
+          );
         });
   }
 }

--- a/lib/shared/widgets/menus/character_context_menu/character_context_menu.dart
+++ b/lib/shared/widgets/menus/character_context_menu/character_context_menu.dart
@@ -39,7 +39,7 @@ class CharacterContextMenu extends BaseOverlayWidget {
         Positioned(
             bottom: sourceBottom + kToolbarHeight + viewPadding.bottom,
             left: 0,
-            top: 0,
+            top: viewPadding.top,
             right: sourceRight,
             child: Container(padding: const EdgeInsets.all(8), child: buildMenuItems(context))),
         Positioned(


### PR DESCRIPTION
- Toggles at top of CharacterContextMenu were into phones notch area so couldn't be used. This adds the proper padding at the top.
- Added SafeArea widget around bottomsheet to ensure proper padding for any phone