### PR TITLE
Don't show duplicates of non-equippable items

### DIFF
--- a/lib/modules/item_details/pages/inventory_item_details/inventory_item_details.bloc.dart
+++ b/lib/modules/item_details/pages/inventory_item_details/inventory_item_details.bloc.dart
@@ -206,6 +206,8 @@ class InventoryItemDetailsBloc extends ItemDetailsBloc {
   }
 
   List<InventoryItemInfo>? get duplicates {
+    final def = _manifestBloc.definition<DestinyInventoryItemDefinition>(this.item?.itemHash);
+    if ((def?.equippable ?? true) == false) return null;
     return this.item?.duplicates?.where((element) => element != this.item).toList();
   }
 

--- a/lib/modules/item_details/pages/vendor_item_details/vendor_item_details.bloc.dart
+++ b/lib/modules/item_details/pages/vendor_item_details/vendor_item_details.bloc.dart
@@ -178,6 +178,8 @@ class VendorItemDetailsBloc extends ItemDetailsBloc {
   }
 
   List<InventoryItemInfo>? get duplicates {
+    final def = _manifestBloc.definition<DestinyInventoryItemDefinition>(this.item?.itemHash);
+    if ((def?.equippable ?? true) == false) return null;
     return this._profileBloc.getItemsByHash(this.itemHash);
   }
 


### PR DESCRIPTION
This makes non-equippable items such as engrams and upgrade materials no longer show duplicates for items sold by vendors or in the postmaster. It uses the equippable flag from the item definition rather than info from the profile since we want to show things like vendor armor that can be equipped by other characters.