### PR TITLE
Fixed stack transfers with more than 1 item

### DIFF
--- a/lib/modules/item_details/pages/inventory_item_details/inventory_item_details.bloc.dart
+++ b/lib/modules/item_details/pages/inventory_item_details/inventory_item_details.bloc.dart
@@ -309,7 +309,7 @@ class InventoryItemDetailsBloc extends ItemDetailsBloc {
     final item = this.item;
     if (item == null) return;
     if (actionType == TransferActionType.Transfer) {
-      _inventoryBloc.transfer(item, destination);
+      _inventoryBloc.transfer(item, destination, stackSize: stackSize);
     } else {
       _inventoryBloc.equip(item, destination);
     }


### PR DESCRIPTION
Stack transfers of consumables such as spoils or enhancement prisms would only transfer 1 at a time even when more were selected via the slider.