### PR TITLE
Fixes crafting pattern progress missing for Fang of Ir Yut and Song of

### DIFF
--- a/lib/services/manifest/manifest.service.dart
+++ b/lib/services/manifest/manifest.service.dart
@@ -270,7 +270,7 @@ class ManifestService extends ChangeNotifier with StorageConsumer, BungieApiCons
     String? where;
     if (parameters != null && parameters.isNotEmpty) {
       where = parameters.map((p) {
-        return "UPPER(json) LIKE \"%${p.toUpperCase()}%\"";
+        return "UPPER(json) LIKE UPPER(\"%$p%\")";
       }).join(" AND ");
     }
     if (tableName == null) {


### PR DESCRIPTION
This fixes missing pattern progress for Fang of Ir Yut and Song of Ir Yut. Both weapons contain the name "Yut" which has a circumflex mark over the "u".  Apparently, the methods used to convert the special character "u" to uppercase by sqllite and dart are incompatible in the following line:
`return "UPPER(json) LIKE \"%${p.toUpperCase()}%\"";`

![image](https://github.com/LittleLightForDestiny/littlelight/assets/68356139/f0610914-1c13-4f7d-9b56-be43775bbd0f)
