### PR TITLE
Fixes icons not loading due to hash changes.

### DIFF
--- a/lib/modules/progress/widgets/progress_type_tab_menu.widget.dart
+++ b/lib/modules/progress/widgets/progress_type_tab_menu.widget.dart
@@ -5,7 +5,7 @@ import 'package:little_light/shared/widgets/tabs/custom_tab/custom_tab.dart';
 import 'package:little_light/shared/widgets/tabs/custom_tab/custom_tab_menu.dart';
 import 'package:little_light/widgets/common/manifest_image.widget.dart';
 
-const _milestonesQuestStepNodeHash = 3130110908;
+const _milestonesQuestStepNodeHash = 4018888208;
 const _pursuitsIconRecordHash = 435168078;
 const _ranksIconObjectiveHash = 1674713289;
 

--- a/lib/shared/widgets/character/character_info.widget.dart
+++ b/lib/shared/widgets/character/character_info.widget.dart
@@ -12,7 +12,7 @@ import 'package:little_light/widgets/common/manifest_text.widget.dart';
 import 'package:little_light/widgets/icon_fonts/littlelight_icons.dart';
 import 'package:intl/intl.dart';
 
-const _wellRestedProgression = 2352765282;
+const _wellRestedProgression = 1519921522;
 
 class CharacterInfoWidget extends StatelessWidget with DestinySettingsConsumer {
   final DestinyCharacterInfo character;


### PR DESCRIPTION
2 icons were not loading due to hash value changes:
- _milestonesQuestStepNodeHash
- _wellRestedProgression
![image](https://github.com/LittleLightForDestiny/littlelight/assets/68356139/ad71d0b5-90d4-45b1-a002-fa738c67c8ad)
