### PR TITLE
Fixes missing crafting pattern progress by searching character scoped records

### DIFF
--- a/lib/core/blocs/profile/craftables_helper.bloc.dart
+++ b/lib/core/blocs/profile/craftables_helper.bloc.dart
@@ -31,7 +31,14 @@ class CraftablesHelperBloc extends ChangeNotifier {
     }
     final recordHash = _itemToRecordHashMap[itemHash];
     if (recordHash == null) return null;
-    return _profileBloc.getProfileRecord(recordHash);
+    final profileRecord = _profileBloc.getProfileRecord(recordHash);
+    if (profileRecord != null) return profileRecord;
+    return _profileBloc.characters
+        ?.map((c) => c.characterId)
+        .whereType<String>()
+        .map((id) => _profileBloc.getCharacterRecord(id, recordHash))
+        .whereType<DestinyRecordComponent>()
+        .firstOrNull;
   }
 
   List<DestinyObjectiveProgress>? getItemCraftedObjectives(DestinyItemInfo item) {


### PR DESCRIPTION
Some seasonal weapons have their pattern progress records (apparently mistakenly) set to character scoped so we weren't finding them. Now if we know there is a record, but don't find it in the profile records, we will search the character records.