### PR TITLE
Show energy capacity, energy capacity and cost values in stats diff, other fixes.

### DIFF
--- a/lib/modules/item_details/widgets/details_plug_info.widget.dart
+++ b/lib/modules/item_details/widgets/details_plug_info.widget.dart
@@ -169,8 +169,18 @@ class DetailsPlugInfoWidget extends StatelessWidget {
 
   Widget buildEnergyCost(BuildContext context, int plugHash) {
     final definition = context.definition<DestinyInventoryItemDefinition>(plugHash);
+    int value = 0;
+    String text = "";
     final cost = definition?.plug?.energyCost?.energyCost;
-    if (cost == null) return Container();
+    final capacity = definition?.plug?.energyCapacity?.capacityValue;
+    if (cost != null) {
+      value = cost;
+      text = "Energy Cost".translate(context).toUpperCase();
+    } else if (capacity != null) {
+      value = capacity;
+      text = "Energy Capacity".translate(context).toUpperCase();
+    } else
+      return Container();
     return buildInfoContainer(
       context,
       Row(
@@ -178,10 +188,10 @@ class DetailsPlugInfoWidget extends StatelessWidget {
           Container(width: 20, child: Image.asset('assets/imgs/energy-type-icon.png')),
           Container(
             padding: const EdgeInsets.all(4),
-            child: Text("$cost", style: context.textTheme.itemPrimaryStatHighDensity),
+            child: Text("$value", style: context.textTheme.itemPrimaryStatHighDensity),
           ),
           Text(
-            "Energy Cost".translate(context).toUpperCase(),
+            text,
             style: context.textTheme.body,
           ),
         ],

--- a/lib/modules/item_details/widgets/details_plug_stats.widget.dart
+++ b/lib/modules/item_details/widgets/details_plug_stats.widget.dart
@@ -32,7 +32,7 @@ class DetailsPlugStatsWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
         decoration: BoxDecoration(
-          color: context.theme.surfaceLayers.layer0,
+          color: context.theme.surfaceLayers.layer1,
           borderRadius: BorderRadius.circular(4),
         ),
         margin: EdgeInsets.only(top: 4),
@@ -43,9 +43,9 @@ class DetailsPlugStatsWidget extends StatelessWidget {
   Widget buildTable(BuildContext context) {
     return Table(
       defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      defaultColumnWidth: FlexColumnWidth(1),
       columnWidths: {
-        0: IntrinsicColumnWidth(flex: 2),
-        1: FlexColumnWidth(omitComparison ? 2 : 1),
+        0: IntrinsicColumnWidth(flex: omitComparison ? 1 : 3),
       },
       children: [
         buildHeaderRow(context),
@@ -86,6 +86,7 @@ class DetailsPlugStatsWidget extends StatelessWidget {
         stat.statHash,
         textAlign: TextAlign.end,
         softWrap: false,
+        overflow: TextOverflow.fade,
         style: context.textTheme.body.copyWith(fontSize: fontSize),
       ),
       buildStatValue(context, stat.selected, stat.selectedDiffType),

--- a/lib/modules/item_details/widgets/item_cover/details_item_cover_plug_info.widget.dart
+++ b/lib/modules/item_details/widgets/item_cover/details_item_cover_plug_info.widget.dart
@@ -173,8 +173,18 @@ class DetailsItemCoverPlugInfoWidget extends StatelessWidget {
 
   Widget buildEnergyCost(BuildContext context, int plugHash) {
     final definition = context.definition<DestinyInventoryItemDefinition>(plugHash);
+    int value = 0;
+    String text = "";
     final cost = definition?.plug?.energyCost?.energyCost;
-    if (cost == null) return Container();
+    final capacity = definition?.plug?.energyCapacity?.capacityValue;
+    if (cost != null) {
+      value = cost;
+      text = "Energy Cost".translate(context).toUpperCase();
+    } else if (capacity != null) {
+      value = capacity;
+      text = "Energy Capacity".translate(context).toUpperCase();
+    } else
+      return Container();
     return buildInfoContainer(
       context,
       Row(
@@ -183,10 +193,10 @@ class DetailsItemCoverPlugInfoWidget extends StatelessWidget {
           Container(
             padding: EdgeInsets.symmetric(horizontal: 16 * pixelSize),
             child:
-                Text("$cost", style: context.textTheme.itemPrimaryStatHighDensity.copyWith(fontSize: 48 * pixelSize)),
+                Text("$value", style: context.textTheme.itemPrimaryStatHighDensity.copyWith(fontSize: 48 * pixelSize)),
           ),
           Text(
-            "Energy Cost".translate(context).toUpperCase(),
+            text,
             style: context.textTheme.body.copyWith(fontSize: 24 * pixelSize),
           ),
         ],

--- a/lib/modules/loadouts/pages/edit_loadout_item_mods/loadout_item_socket_controller.bloc.dart
+++ b/lib/modules/loadouts/pages/edit_loadout_item_mods/loadout_item_socket_controller.bloc.dart
@@ -78,7 +78,7 @@ class LoadoutItemSocketControllerBloc extends SocketControllerBloc<LoadoutItemIn
 
   @override
   Future<bool> calculateHasEnoughEnergyFor(int socketIndex, int plugHash) async {
-    final availableEnergy = availableEnergyCapacity?.equipped ?? 0;
+    final availableEnergy = availableEnergyCapacity?.selected ?? 0;
     final usedEnergy = usedEnergyCapacity?.selected ?? 0;
     final currentPlugHash = selectedPlugHashForSocket(socketIndex) ?? equippedPlugHashForSocket(socketIndex);
     final currentPlugDef = await manifest.getDefinition<DestinyInventoryItemDefinition>(currentPlugHash);

--- a/lib/shared/widgets/sockets/mod_icon.widget.dart
+++ b/lib/shared/widgets/sockets/mod_icon.widget.dart
@@ -66,7 +66,7 @@ class ModIconWidget extends StatelessWidget {
 
   Widget? buildEnergyTypeOverlay(BuildContext context, DestinyInventoryItemDefinition? def) {
     var energyType = def?.plug?.energyCost?.energyType ?? DestinyEnergyType.Any;
-    if ([DestinyEnergyType.Any, DestinyEnergyType.Subclass].contains(energyType)) return null;
+    if ([DestinyEnergyType.Any, DestinyEnergyType.Subclass, DestinyEnergyType.Ghost].contains(energyType)) return null;
 
     return Positioned.fill(
       child: ManifestImageWidget<DestinyStatDefinition>(

--- a/lib/shared/widgets/sockets/mod_icon.widget.dart
+++ b/lib/shared/widgets/sockets/mod_icon.widget.dart
@@ -76,8 +76,15 @@ class ModIconWidget extends StatelessWidget {
   }
 
   Widget? buildEnergyCostOverlay(BuildContext context, DestinyInventoryItemDefinition? def) {
-    var energyCost = def?.plug?.energyCost?.energyCost ?? 0;
-    if (energyCost == 0) return null;
+    final energyCost = def?.plug?.energyCost?.energyCost ?? 0;
+    final energyCapacity = def?.plug?.energyCapacity?.capacityValue ?? 0;
+    String text = "";
+    if (energyCost > 0)
+      text = "$energyCost";
+    else if (energyCapacity > 0)
+      text = "+$energyCapacity";
+    else
+      return null;
     return Positioned.fill(
       child: LayoutBuilder(
         builder: (context, constraints) {
@@ -91,7 +98,7 @@ class ModIconWidget extends StatelessWidget {
                 right: 12,
               ),
               child: Text(
-                "$energyCost",
+                text,
                 style: const TextStyle(fontSize: 16),
               ),
             ),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/942ac02d-9e9b-4ec9-b0ab-c16054662e57)
- Fixed never ending loading animation on ghost mods.
- Fixed loadout subclass energy capacity to use aspects in loadout instead of actual equipped aspects when changing fragments.
- Added display of energy capacity to plug info similiar to energy cost.
- Added display of numeric energy capacity value to aspect icons similiar to energy cost, except with a leading "+" to differentiate it from cost.
- Fixed mod stats calculations so correct energy cost and capacity values show (instead of 0) when changing subclass, armor, and ghost mods.
- Changed DetailsPlugStatsWidget to show stat names in 1/2 of width and stat differences in other 1/2 of width to prevent stat name overflow. Changed background color to match adjacent boxes.