### PR TITLE
Add Windows build dependency

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Here are some tips to make sure your pull request can be merged smoothly:
 
 ### Pre-requisites
 * Install [Flutter SDK](https://flutter.dev/docs/get-started/install).
+   * *For Windows Builds:* Install Visual Studio and make sure to include the workload "Desktop development with C++"
 * Make sure you're on Flutter's stable channel. To know what channel you're on, run ```flutter channel``` on Terminal/Bash.
 * Setup your [favorite code editor](https://flutter.dev/docs/get-started/editor) (I recommend using [VS Code](https://code.visualstudio.com/))
 


### PR DESCRIPTION
It's written right in the Flutter documentation but I missed it initially